### PR TITLE
Fix errors brought by tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
     here = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(here, "requirements.txt")) as f:
         required = [
-            l.strip("\n") for l in f if l.strip("\n") and not l.startswith("#")
+            line.strip("\n") for line in f if line.strip("\n") and not line.startswith("#")
         ]
 except IOError:
     required = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,flake8,docs
+envlist = py36,py37,py38,flake8,docs
 toxworkdir={toxinidir}/.tox
 
 [testenv]


### PR DESCRIPTION
* Stopped using python3.4 and python 3.5 and added python3.8
* Fixed the 'ambiguous variable name' in setup.py as it will interfere
with CI verification