### PR TITLE
Block PR to master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: PR on master is not allowed, All PR should target develop branch.
+# action that simply fails on PRs that are based on master 
+on: 
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  fail:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: failfast
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fantastic-API  is a recruitment test to check the candidate performance on :
 ## TODO
 
 - Follow the instructions below to clone and run this project 
-- Explores and make a proposal for the issues opened by @yurilaaziz 
+- Explore and make a proposal for the issues opened by @yurilaaziz 
 
 
 ## Installation


### PR DESCRIPTION
Pull Requests that are based on the `master` branch are failed automatically by GitHub without going through the Jenkins CI