### PR TITLE
Meriem

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,18 @@
 [tox]
 envlist = py36,py37,py38,flake8,docs
+usesdist=false
 toxworkdir={toxinidir}/.tox
 
 [testenv]
+basepython = python3
 deps = -r{toxinidir}/requirements.txt
       pytest
       coverage
 commands =
     python --version
     py.test 
-passenv =
+passenv = *
+
     HOME
     CI
     TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps = -r{toxinidir}/requirements.txt
 commands =
     python --version
     py.test 
-passenv = *
+passenv = 
 
     HOME
     CI


### PR DESCRIPTION
tox will create py36, py38 virtualenvs in .tox and run our commands in each of them in turn (in my case the Python 3.6 and 3.8  testenv fail because I only have Python 3.7 on my laptop and i fix the problem.
